### PR TITLE
Generalmaintenance email from 2021-6-29

### DIFF
--- a/ArchitectAdviceReport.php
+++ b/ArchitectAdviceReport.php
@@ -79,7 +79,9 @@
 <div id="AdviceCustomerDetails" class="container">
 <!--Report Header and Notes-->
 <input class="form-control" type="text" title="name" id="reportheader" style="display:none" value="<?php echo doNiceArrayElemAsString('reportheader') ?>">
-<input class="form-control" type="text" title="name" id="reportnotes"  style="display:none" value="<?php echo doNiceArrayElemAsString('reportnotes') ?>">
+<!-- <input class="form-control" type="text" title="name" id="reportnotes"  style="display:none" value="<?php echo doNiceArrayElemAsString('reportnotes') ?>"> -->
+<input class="form-control" type="text" title="name" id="reportnotes"  style="display:none" value="<?php echo $booking['reportnotes']; ?>">
+
 
     <hr>
     <h3 class="sectionSubHead">CLIENT DETAILS</h3>

--- a/ArchitectAdviceReport.php
+++ b/ArchitectAdviceReport.php
@@ -79,7 +79,6 @@
 <div id="AdviceCustomerDetails" class="container">
 <!--Report Header and Notes-->
 <input class="form-control" type="text" title="name" id="reportheader" style="display:none" value="<?php echo doNiceArrayElemAsString('reportheader') ?>">
-<!-- <input class="form-control" type="text" title="name" id="reportnotes"  style="display:none" value="<?php echo doNiceArrayElemAsString('reportnotes') ?>"> -->
 <input class="form-control" type="text" title="name" id="reportnotes"  style="display:none" value="<?php echo $booking['reportnotes']; ?>">
 
 


### PR DESCRIPTION
Issue: The Report Notes in Architect Advice PDF report, the first letter of every word is upper-class, not the way they are entered. 
Has correct this bug. 

